### PR TITLE
feat: add real estate website content

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -1,0 +1,220 @@
+/* Genel Ayarlar */
+:root {
+  --primary-color: #0066ff;
+  --secondary-color: #00cc66;
+  --dark-color: #333;
+  --light-color: #f8f9fa;
+}
+
+body {
+  font-family: 'Poppins', sans-serif;
+  margin: 0;
+  background-color: var(--light-color);
+  color: var(--dark-color);
+}
+
+/* Navbar */
+.navbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 2rem;
+  background-color: #fff;
+  border-bottom: 1px solid #eee;
+}
+
+.logo img {
+  height: 40px;
+}
+
+.nav-links {
+  list-style: none;
+  display: flex;
+  gap: 1.5rem;
+}
+
+.nav-links a {
+  text-decoration: none;
+  color: var(--dark-color);
+  font-weight: 600;
+  transition: color 0.3s ease;
+}
+
+.nav-links a:hover,
+.nav-links a.active {
+  color: var(--primary-color);
+}
+
+/* Hamburger Menü */
+.menu-toggle {
+  display: none;
+  font-size: 1.5rem;
+  background: none;
+  border: none;
+}
+
+/* Hero */
+.hero {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 3rem 2rem;
+  background: linear-gradient(135deg, var(--primary-color), var(--secondary-color));
+  color: #fff;
+}
+
+.hero-content {
+  max-width: 600px;
+}
+
+.hero-content h1 {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+}
+
+.hero-content p {
+  font-size: 1.1rem;
+  margin-bottom: 1.5rem;
+}
+
+.btn-primary {
+  display: inline-block;
+  padding: 0.75rem 1.5rem;
+  background-color: #fff;
+  color: var(--primary-color);
+  font-weight: 600;
+  text-decoration: none;
+  border-radius: 4px;
+  transition: background-color 0.3s, color 0.3s;
+}
+
+.btn-primary:hover {
+  background-color: var(--dark-color);
+  color: #fff;
+}
+
+/* Özellikler (Anasayfa) */
+.features {
+  display: flex;
+  gap: 2rem;
+  padding: 2rem;
+  text-align: center;
+}
+
+.feature {
+  flex: 1;
+}
+
+/* Sayfa İçerikleri */
+.page-content {
+  padding: 2rem;
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.page-content h1 {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+/* Hizmetler sayfası */
+.services-list {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.services-list article {
+  background: #fff;
+  padding: 1.5rem;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+}
+
+/* Hakkımızda - Ekibimiz */
+.team {
+  margin-top: 2rem;
+}
+
+.team-members {
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.team-member {
+  flex: 1 1 200px;
+  text-align: center;
+}
+
+.team-member img {
+  max-width: 100%;
+  border-radius: 4px;
+}
+
+.contact-info p,
+.contact-form {
+  max-width: 600px;
+  margin: 1rem auto;
+}
+
+/* İletişim Formu */
+.contact-form form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.contact-form label {
+  font-weight: 600;
+}
+
+.contact-form input,
+.contact-form textarea {
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+/* Footer */
+.site-footer {
+  text-align: center;
+  padding: 1rem;
+  background-color: #fff;
+  border-top: 1px solid #eee;
+}
+
+/* Responsive Ayarlar */
+@media (max-width: 768px) {
+  .nav-links {
+    position: absolute;
+    top: 60px;
+    right: 0;
+    background-color: #fff;
+    flex-direction: column;
+    width: 200px;
+    padding: 1rem;
+    gap: 0;
+    display: none;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  }
+  .nav-links.show {
+    display: flex;
+  }
+  .menu-toggle {
+    display: block;
+  }
+  .features {
+    flex-direction: column;
+  }
+  .hero {
+    flex-direction: column;
+    text-align: center;
+  }
+  .hero-image {
+    margin-top: 2rem;
+  }
+  .team-members {
+    flex-direction: column;
+  }
+}

--- a/public/assets/img/logo.svg
+++ b/public/assets/img/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="150" height="40" viewBox="0 0 150 40" fill="none">
+  <rect x="0" y="0" width="150" height="40" rx="4" fill="#0066FF"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="20" font-family="Poppins" font-weight="700" fill="white">Aydın Emlak</text>
+</svg>

--- a/public/assets/js/script.js
+++ b/public/assets/js/script.js
@@ -1,0 +1,7 @@
+// Mobil menü toggle
+const menuToggle = document.querySelector('.menu-toggle');
+const navLinks = document.querySelector('.nav-links');
+
+menuToggle.addEventListener('click', () => {
+  navLinks.classList.toggle('show');
+});

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://www.ornek-domain.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://www.ornek-domain.com/</loc>
+    <lastmod>2024-05-01</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://www.ornek-domain.com/hizmetler</loc>
+    <lastmod>2024-05-01</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.ornek-domain.com/hakkimizda</loc>
+    <lastmod>2024-05-01</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://www.ornek-domain.com/iletisim</loc>
+    <lastmod>2024-05-01</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+</urlset>

--- a/src/components/SeoHead.astro
+++ b/src/components/SeoHead.astro
@@ -8,8 +8,8 @@ interface Props {
 
 const {
   title,
-  description = "Kişisel kurumsal web sitem. Hizmetlerim, referanslarım ve iletişim.",
-  url = "https://www.ornekdoman.com",
+  description = "Aydın bölgesinde profesyonel gayrimenkul danışmanlığı hizmetleri.",
+  url = "https://www.ornek-domain.com",
   image = "/og-image.jpg",
 } = Astro.props;
 ---

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,32 +1,57 @@
 ---
 import SeoHead from "../components/SeoHead.astro";
-
 const { title = "Anasayfa", description } = Astro.props;
 ---
-
 <html lang="tr">
   <head>
-    <SeoHead title={`Ad Soyad | ${title}`} description={description} />
-    <link rel="icon" href="/favicon.svg" />
+    <SeoHead title={`Aydın Emlak – ${title}`} description={description} />
+    <link rel="icon" href="/assets/img/logo.svg" />
+    <link rel="stylesheet" href="/assets/css/style.css" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
-    <header style="padding:16px 0; border-bottom:1px solid #eee;">
-      <nav style="display:flex; gap:16px;">
-        <a href="/">Ana Sayfa</a>
-        <a href="/hakkimizda">Hakkımızda</a>
-        <a href="/hizmetler">Hizmetler</a>
-        <a href="/iletisim">İletişim</a>
+    <header class="site-header">
+      <nav class="navbar">
+        <a href="/" class="logo">
+          <img src="/assets/img/logo.svg" alt="Aydın Emlak Logo" />
+        </a>
+        <button class="menu-toggle" aria-label="Menüyü Aç/Kapat">&#9776;</button>
+        <ul class="nav-links">
+          <li>
+            <a href="/" class={Astro.url.pathname === "/" ? "active" : ""}>
+              Anasayfa
+            </a>
+          </li>
+          <li>
+            <a href="/hizmetler" class={Astro.url.pathname.startsWith("/hizmetler") ? "active" : ""}>
+              Hizmetler
+            </a>
+          </li>
+          <li>
+            <a href="/hakkimizda" class={Astro.url.pathname.startsWith("/hakkimizda") ? "active" : ""}>
+              Hakkımızda
+            </a>
+          </li>
+          <li>
+            <a href="/iletisim" class={Astro.url.pathname.startsWith("/iletisim") ? "active" : ""}>
+              İletişim
+            </a>
+          </li>
+        </ul>
       </nav>
     </header>
 
-    <main style="max-width:960px; margin:32px auto; padding:0 16px;">
+    <main class="page-content">
       <slot />
     </main>
 
-    <footer
-      style="padding:24px 0; border-top:1px solid #eee; text-align:center;"
-    >
-      © {new Date().getFullYear()} Ad Soyad — Tüm hakları saklıdır.
+    <footer class="site-footer">
+      <p>&copy; {new Date().getFullYear()} Aydın Emlak. Tüm hakları saklıdır.</p>
     </footer>
+
+    <script src="/assets/js/script.js" is:inline></script>
   </body>
 </html>

--- a/src/pages/hakkimizda.astro
+++ b/src/pages/hakkimizda.astro
@@ -1,8 +1,26 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
 ---
+<BaseLayout
+  title="Hakkımızda"
+  description="Aydın Emlak hakkında bilgi edinin. Misyonumuz, vizyonumuz ve ekibimiz."
+>
+  <h1>Hakkımızda</h1>
+  <p>Aydın Emlak, gayrimenkul sektöründe uzun yıllara dayanan tecrübesiyle müşterilerine güvenilir ve profesyonel hizmet sunar. Misyonumuz, her müşterinin ihtiyaçlarına özel çözümler sağlayarak memnuniyetlerini en üst seviyeye çıkarmaktır.</p>
 
-<BaseLayout title="Hakkımızda">
-  <h1>Hakkımda</h1>
-  <p>Kısa biyografi, misyon & vizyon, değerler.</p>
+  <section class="team">
+    <h2>Ekibimiz</h2>
+    <div class="team-members">
+      <div class="team-member">
+        <img src="/assets/img/team-member1.jpg" alt="Danışman 1" />
+        <h3>Danışman Adı 1</h3>
+        <p>Gayrimenkul Danışmanı</p>
+      </div>
+      <div class="team-member">
+        <img src="/assets/img/team-member2.jpg" alt="Danışman 2" />
+        <h3>Danışman Adı 2</h3>
+        <p>Müşteri İlişkileri Uzmanı</p>
+      </div>
+    </div>
+  </section>
 </BaseLayout>

--- a/src/pages/hizmetler.astro
+++ b/src/pages/hizmetler.astro
@@ -1,11 +1,23 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
 ---
-
-<BaseLayout title="Hizmetler">
-  <h1>Hizmetler</h1>
-  <h2>Hizmet A</h2>
-  <p>Kapsam, teslimatlar, örnek çalışmalar.</p>
-  <h2>Hizmet B</h2>
-  <p>…</p>
+<BaseLayout
+  title="Hizmetler"
+  description="Satılık ve kiralık emlak hizmetleri, değerleme, danışmanlık ve daha fazlası."
+>
+  <h1>Hizmetlerimiz</h1>
+  <div class="services-list">
+    <article>
+      <h2>Satılık ve Kiralık Mülkler</h2>
+      <p>Aydın’da satılık ve kiralık daire, villa, arsa ve ticari mülk seçenekleri.</p>
+    </article>
+    <article>
+      <h2>Mülk Değerleme</h2>
+      <p>Uzman ekibimizle piyasa koşullarına göre doğru değerleme.</p>
+    </article>
+    <article>
+      <h2>Danışmanlık ve Yatırım</h2>
+      <p>Yatırımcılar için kapsamlı danışmanlık hizmeti.</p>
+    </article>
+  </div>
 </BaseLayout>

--- a/src/pages/iletisim.astro
+++ b/src/pages/iletisim.astro
@@ -1,11 +1,28 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
 export let title: string = "İletişim";
-export let description: string = "Bize ulaşın";
+export let description: string = "Aydın Emlak ile iletişime geçin. Adres, telefon ve e-posta bilgilerimiz.";
 ---
-
 <BaseLayout title={title} description={description}>
   <h1>İletişim</h1>
-  <p>E-posta: <a href="mailto:info@ornek.com">info@ornek.com</a></p>
-  <p>Telefon: +90 555 555 55 55</p>
+  <div class="contact-info">
+    <p><strong>Adres:</strong> [Adresinizi buraya girin]</p>
+    <p><strong>Telefon:</strong> <a href="tel:+900000000000">+90 000 000 00 00</a></p>
+    <p><strong>E-posta:</strong> <a href="mailto:info@aydin-emlak.com">info@aydin-emlak.com</a></p>
+  </div>
+  <section class="contact-form">
+    <h2>İletişim Formu</h2>
+    <form action="#" method="POST">
+      <label for="name">Ad Soyad</label>
+      <input type="text" id="name" name="name" required />
+
+      <label for="email">E-posta</label>
+      <input type="email" id="email" name="email" required />
+
+      <label for="message">Mesajınız</label>
+      <textarea id="message" name="message" rows="5" required></textarea>
+
+      <button type="submit" class="btn-primary">Gönder</button>
+    </form>
+  </section>
 </BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,16 +1,33 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
 ---
-
 <BaseLayout
-  title="Ana Sayfa"
-  description="Kurumsal kişisel web siteme hoş geldiniz."
+  title="Profesyonel Gayrimenkul Danışmanlığı"
+  description="Aydın'da güvenilir emlak hizmetleri."
 >
-  <h1>Merhaba, ben Ad Soyad</h1>
-  <p>Alanım: Danışmanlık / Yazılım / Mimarlık ...</p>
-  <ul>
-    <li>10+ yıl deneyim</li>
-    <li>Kurumsal referanslar</li>
-    <li>Uzmanlık: ...</li>
-  </ul>
+  <section class="hero">
+    <div class="hero-content">
+      <h1>Aydın’da Güvenilir Emlak Hizmetleri</h1>
+      <p>Aydın Emlak ile hayalinizdeki mülkü bulun. Profesyonel danışmanlık, geniş portföy ve şeffaf hizmet.</p>
+      <a href="/hizmetler" class="btn-primary">Hizmetlerimizi Keşfedin</a>
+    </div>
+    <div class="hero-image">
+      <!-- <img src="/assets/img/hero.jpg" alt="Aydın Emlak" /> -->
+    </div>
+  </section>
+
+  <section class="features">
+    <div class="feature">
+      <h3>Geniş Portföy</h3>
+      <p>Aydın ve çevresinde geniş mülk seçenekleriyle aradığınızı kolayca bulun.</p>
+    </div>
+    <div class="feature">
+      <h3>Profesyonel Danışmanlık</h3>
+      <p>Alanında uzman ekibimizle yatırımınız için doğru adımları atın.</p>
+    </div>
+    <div class="feature">
+      <h3>Hızlı İşlem</h3>
+      <p>Tüm süreçlerde hızlı ve şeffaf hizmet anlayışı.</p>
+    </div>
+  </section>
 </BaseLayout>


### PR DESCRIPTION
## Summary
- build responsive layout with SEO head, navigation, and global styles for Aydın Emlak
- add index, hizmetler, hakkımızda, and iletişim pages with placeholder content
- include global CSS/JS, logo, robots and sitemap files

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a45a504c1883238f5a7a946ac19ef7