### PR TITLE
feat: modern layout with header hero and footer

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -13,14 +13,26 @@ body {
   color: var(--dark-color);
 }
 
-/* Navbar */
-.navbar {
+/* Helpers */
+.container {
+  width: min(90%, 1200px);
+  margin: 0 auto;
+}
+
+/* Header */
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  background-color: #fff;
+  border-bottom: 1px solid #eee;
+}
+
+.header-inner {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1rem 2rem;
-  background-color: #fff;
-  border-bottom: 1px solid #eee;
+  padding: 1rem 0;
 }
 
 .logo img {
@@ -55,12 +67,16 @@ body {
 
 /* Hero */
 .hero {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 3rem 2rem;
   background: linear-gradient(135deg, var(--primary-color), var(--secondary-color));
   color: #fff;
+  padding: 4rem 0;
+}
+
+.hero-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+  align-items: center;
 }
 
 .hero-content {
@@ -68,7 +84,7 @@ body {
 }
 
 .hero-content h1 {
-  font-size: 2.5rem;
+  font-size: 3rem;
   margin-bottom: 1rem;
 }
 
@@ -179,7 +195,7 @@ body {
 /* Footer */
 .site-footer {
   text-align: center;
-  padding: 1rem;
+  padding: 2rem 0;
   background-color: #fff;
   border-top: 1px solid #eee;
 }
@@ -207,8 +223,7 @@ body {
   .features {
     flex-direction: column;
   }
-  .hero {
-    flex-direction: column;
+  .hero-grid {
     text-align: center;
   }
   .hero-image {

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,0 +1,5 @@
+<footer class="site-footer">
+  <div class="container">
+    <p>&copy; {new Date().getFullYear()} Aydın Emlak. Tüm hakları saklıdır.</p>
+  </div>
+</footer>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,0 +1,26 @@
+---
+const { currentPath = '/' } = Astro.props;
+const links = [
+  { href: '/', label: 'Anasayfa' },
+  { href: '/hizmetler', label: 'Hizmetler' },
+  { href: '/hakkimizda', label: 'Hakkımızda' },
+  { href: '/iletisim', label: 'İletişim' }
+];
+---
+<header class="site-header">
+  <div class="container header-inner">
+    <a href="/" class="logo">
+      <img src="/assets/img/logo.svg" alt="Aydın Emlak Logo" />
+    </a>
+    <button class="menu-toggle" aria-label="Menüyü Aç/Kapat">&#9776;</button>
+    <nav>
+      <ul class="nav-links">
+        {links.map(link => (
+          <li>
+            <a href={link.href} class={currentPath === link.href ? 'active' : ''}>{link.label}</a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  </div>
+</header>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,0 +1,24 @@
+---
+interface Props {
+  title: string;
+  text: string;
+  ctaText: string;
+  ctaLink: string;
+  image?: string;
+}
+const { title, text, ctaText, ctaLink, image } = Astro.props as Props;
+---
+<section class="hero">
+  <div class="container hero-grid">
+    <div class="hero-content">
+      <h1>{title}</h1>
+      <p>{text}</p>
+      <a href={ctaLink} class="btn-primary">{ctaText}</a>
+    </div>
+    {image && (
+      <div class="hero-image">
+        <img src={image} alt="" />
+      </div>
+    )}
+  </div>
+</section>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,6 +1,9 @@
 ---
 import SeoHead from "../components/SeoHead.astro";
+import Header from "../components/Header.astro";
+import Footer from "../components/Footer.astro";
 const { title = "Anasayfa", description } = Astro.props;
+const currentPath = Astro.url.pathname;
 ---
 <html lang="tr">
   <head>
@@ -13,45 +16,11 @@ const { title = "Anasayfa", description } = Astro.props;
     />
   </head>
   <body>
-    <header class="site-header">
-      <nav class="navbar">
-        <a href="/" class="logo">
-          <img src="/assets/img/logo.svg" alt="Aydın Emlak Logo" />
-        </a>
-        <button class="menu-toggle" aria-label="Menüyü Aç/Kapat">&#9776;</button>
-        <ul class="nav-links">
-          <li>
-            <a href="/" class={Astro.url.pathname === "/" ? "active" : ""}>
-              Anasayfa
-            </a>
-          </li>
-          <li>
-            <a href="/hizmetler" class={Astro.url.pathname.startsWith("/hizmetler") ? "active" : ""}>
-              Hizmetler
-            </a>
-          </li>
-          <li>
-            <a href="/hakkimizda" class={Astro.url.pathname.startsWith("/hakkimizda") ? "active" : ""}>
-              Hakkımızda
-            </a>
-          </li>
-          <li>
-            <a href="/iletisim" class={Astro.url.pathname.startsWith("/iletisim") ? "active" : ""}>
-              İletişim
-            </a>
-          </li>
-        </ul>
-      </nav>
-    </header>
-
+    <Header currentPath={currentPath} />
     <main class="page-content">
       <slot />
     </main>
-
-    <footer class="site-footer">
-      <p>&copy; {new Date().getFullYear()} Aydın Emlak. Tüm hakları saklıdır.</p>
-    </footer>
-
+    <Footer />
     <script src="/assets/js/script.js" is:inline></script>
   </body>
 </html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,22 +1,19 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
+import Hero from "../components/Hero.astro";
 ---
 <BaseLayout
   title="Profesyonel Gayrimenkul Danışmanlığı"
   description="Aydın'da güvenilir emlak hizmetleri."
 >
-  <section class="hero">
-    <div class="hero-content">
-      <h1>Aydın’da Güvenilir Emlak Hizmetleri</h1>
-      <p>Aydın Emlak ile hayalinizdeki mülkü bulun. Profesyonel danışmanlık, geniş portföy ve şeffaf hizmet.</p>
-      <a href="/hizmetler" class="btn-primary">Hizmetlerimizi Keşfedin</a>
-    </div>
-    <div class="hero-image">
-      <!-- <img src="/assets/img/hero.jpg" alt="Aydın Emlak" /> -->
-    </div>
-  </section>
+  <Hero
+    title="Aydın’da Güvenilir Emlak Hizmetleri"
+    text="Aydın Emlak ile hayalinizdeki mülkü bulun. Profesyonel danışmanlık, geniş portföy ve şeffaf hizmet."
+    ctaText="Hizmetlerimizi Keşfedin"
+    ctaLink="/hizmetler"
+  />
 
-  <section class="features">
+  <section class="features container">
     <div class="feature">
       <h3>Geniş Portföy</h3>
       <p>Aydın ve çevresinde geniş mülk seçenekleriyle aradığınızı kolayca bulun.</p>


### PR DESCRIPTION
## Summary
- add reusable header, hero, and footer components for a modern layout
- update base layout and homepage to use new sections
- refresh CSS with container, sticky header, and responsive hero grid

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a46353301c8323a858a36ca55b33c7